### PR TITLE
solved 2 errors to make it build locally

### DIFF
--- a/pwn/buffer_overflow/Source/run.sh
+++ b/pwn/buffer_overflow/Source/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Default values for optional parameters
-HOSTNAME="localhost"
+HOSTNAME="127.0.0.1"
 PORT=1337
 FLAG=""
 
@@ -38,5 +38,5 @@ fi
 export HOSTNAME=$HOSTNAME
 export PORT=$PORT
 export FLAG=$FLAG
-docker-compose up --build -d
+docker compose up --build -d
 echo "Challenge running on $HOSTNAME:$PORT with $FLAG"


### PR DESCRIPTION
The notation for <IP>:<host port>:<container port> is unfortunately missing from the docker-compose docs, but I did find that it did not support the localhost alias. Additionally, I found that the docker-compose binary is not the right way to invoke it anymore: https://stackoverflow.com/a/78464136. Perhaps something is wrong with my docker?